### PR TITLE
update mac builders tags

### DIFF
--- a/.github/workflows/build-test-distribute.yml
+++ b/.github/workflows/build-test-distribute.yml
@@ -187,7 +187,7 @@ jobs:
 
   macos-build-test:
     timeout-minutes: 40
-    runs-on: [self-hosted, macOS, x64]
+    runs-on: [self-hosted, macOS, x64, not-arm]
     strategy:
       matrix:
         config: [Release]


### PR DESCRIPTION
There is only x64 github runner on MacOS, so on M1 builder it uses Rosetta and automatically sets non-removable `x64`tag